### PR TITLE
Feat: 사용자의 선택에 따른 맵 변경을 위한 드롭다운 구현

### DIFF
--- a/src/components/content/canvas/maps/RootMap.tsx
+++ b/src/components/content/canvas/maps/RootMap.tsx
@@ -5,12 +5,13 @@ import {useRecoilState, useRecoilValue} from "recoil";
 import {CharacterSelectFinishedAtom, PlayersAtom} from "../../../../store/PlayersAtom.ts";
 import {CharacterInit} from "../../lobby/CharacterInit.tsx";
 import {useThree} from "@react-three/fiber";
-import {MutableRefObject, useEffect, useRef} from "react";
+import {MutableRefObject, Suspense, useEffect, useRef} from "react";
 import {OrbitControls as typeOC} from "three-stdlib";
 import {Vector3} from "three";
 import {Man} from "../maps/player/Man.tsx";
 import {Woman} from "../maps/player/Woman.tsx";
 import {Kid} from "../maps/player/Kid.tsx";
+import Loader from "../../loader/Loader.tsx";
 
 
 export const RootMap = () => {
@@ -27,7 +28,7 @@ export const RootMap = () => {
 
     
     return (
-        <>
+        <Suspense fallback={<Loader/>}>
             {!characterSelectFinished ?
                 <CharacterInit/> :
                 (
@@ -82,6 +83,6 @@ export const RootMap = () => {
                 )
 
             }
-        </>
+        </Suspense>
     )
 }

--- a/src/components/content/canvasLayout/Layout.tsx
+++ b/src/components/content/canvasLayout/Layout.tsx
@@ -1,14 +1,27 @@
 import {ReactNode} from "react";
+import { useRecoilValue } from "recoil";
+import { IsLoadCompleteAtom } from "../../../store/PlayersAtom";
+import styled from "styled-components";
+import SideBar from "./canvasUserInterfaces/common/SideBar";
 
 interface CanvasLayoutProps {
     children: ReactNode;
 }
 
+const Wrapper = styled.div`
+    position: relative;
+    width: 100vw;
+    height: 100vh;
+    background-color: transparent;
+`;
+
 const CanvasLayout = ({children} :CanvasLayoutProps) => {
+    const isLoadCompleted = useRecoilValue(IsLoadCompleteAtom);
     return (
-        <>
+        <Wrapper>
             {children}
-        </>
+            {isLoadCompleted && <SideBar/>}
+        </Wrapper>
     );
 };
 

--- a/src/components/content/canvasLayout/canvasUserInterfaces/common/SideBar.tsx
+++ b/src/components/content/canvasLayout/canvasUserInterfaces/common/SideBar.tsx
@@ -1,0 +1,136 @@
+import { useCallback, useState,FC } from "react";
+import { useSetRecoilState,useRecoilValue } from "recoil";
+import { CurrentMapAtom, CurrentMyRoomAtom,MeAtom } from "../../../../../store/PlayersAtom";
+import styled from "styled-components";
+import SportsCricketIcon from '@mui/icons-material/SportsCricket';
+import HomeIcon from '@mui/icons-material/Home';
+import SportsEsportIcon from '@mui/icons-material/SportsEsports';
+import CloseIcon from '@mui/icons-material/Close';
+import MenuIcon from '@mui/icons-material/Menu';
+
+
+const SideBarWrapper = styled.div`
+    transition: 0.4s ease-in-out;
+    position: fixed;
+    left:0;
+    top:0;
+    background-color: #007355;
+    width: 250px;
+    height: 100%;
+    display:flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    align-items: center;
+    padding: 42px 0px;
+    border-radius: 0 10px 10px 0;
+    &.opened {
+        transform: translateX(0);
+    }
+    &.closed{
+        transform: translateX(-100%);
+    }
+
+    div{
+        width: 100%;
+        display: flex;
+        flex-direction: row;
+        justify-content: flex-start;
+        align-items: center;
+        padding: 10px;
+        gap: 10px;
+        border-bottom: 1px solid gray;
+        cursor: pointer;
+        svg{
+            width: 48px;
+            height: 48px;
+            color: #ebb9af;
+        }
+        span{
+            font-size: 18px;
+            padding-top: 8px;
+            color: #ebb9af;
+            font-weight: 500;
+        }
+        & > *{
+            transition: 0.2s ease-in-out;
+        }
+        &:hover{
+            background-color: #ebb9af;
+            & > *{
+                color: #007355;
+            }
+            span {
+                font-size: 20px;
+                font-weight: 800;
+            }
+
+            svg{
+                width: 50px;
+                height: 50px;
+                color: #007355;
+            }
+        }
+    }
+`;
+
+const DropdownController = styled.div`
+    position: absolute;
+    top: 0;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    color: #ebb9af;
+    cursor: pointer;
+    svg{
+        font-weight: 700;
+        width: 42px;
+        height: 42px;
+    }
+    &:hover{
+        transform: scale(1.05);
+    }
+`;
+
+
+
+const SideBar:FC = () => {
+    const [isDropDownOpen, setIsDropDownOpen] = useState(false);
+    const setCurrentMap = useSetRecoilState(CurrentMapAtom);
+    const setCurrentMyRoom = useSetRecoilState(CurrentMyRoomAtom);
+    const me = useRecoilValue(MeAtom);
+
+    const handleClick = useCallback((mapType:string) => (e:React.MouseEvent<HTMLDivElement>) => {
+        e.stopPropagation();
+        setCurrentMyRoom(mapType === "MYROOM" ? me : undefined);
+        setCurrentMap(mapType);
+        setIsDropDownOpen(false);
+    },[me,setCurrentMap,setCurrentMyRoom]);
+
+    return (
+        <>
+            <SideBarWrapper className={isDropDownOpen ? "opened" : "closed"}>
+                <div onClick={handleClick("GROUND")}>
+                    <SportsCricketIcon/>
+                    <span>놀이터로 가기</span>
+                </div>
+                <div onClick={handleClick("MYROOM")}>
+                    <HomeIcon/>
+                    <span>내 방으로 가기</span>
+                </div>
+                <div onClick={handleClick("GAME_ROOM")}>
+                    <SportsEsportIcon/>
+                    <span>게임 방으로 가기</span>
+                </div>
+            </SideBarWrapper>
+            <DropdownController onClick={(e)=>{
+                e.stopPropagation();
+                setIsDropDownOpen(prev => !prev);
+            }}>
+                {isDropDownOpen ? <CloseIcon/> : <MenuIcon/>}
+            </DropdownController>
+        </>
+        
+    );
+};
+
+export default SideBar;

--- a/src/components/content/loader/Loader.tsx
+++ b/src/components/content/loader/Loader.tsx
@@ -1,0 +1,23 @@
+import { Html, useProgress } from "@react-three/drei";
+import { useSetRecoilState } from "recoil";
+import { IsLoadCompleteAtom } from "../../../store/PlayersAtom";
+import { useEffect } from "react";
+
+
+const Loader = () => {
+    const {progress} = useProgress()
+    const setIsLoadCompleted = useSetRecoilState(IsLoadCompleteAtom);
+
+    useEffect(() => {
+        setIsLoadCompleted(progress === 100);
+    }, [progress,setIsLoadCompleted]);
+
+
+    return (
+        <Html center>
+            <progress value={progress}/>
+        </Html>
+    );
+};
+
+export default Loader;

--- a/src/store/PlayersAtom.ts
+++ b/src/store/PlayersAtom.ts
@@ -19,6 +19,7 @@ interface PlayerProps {
     selectedGLBIndex: number;
 }
 
+
 export const MeAtom = atom<meProps|undefined>({
     key: "MeAtom",
     default: undefined,
@@ -50,7 +51,7 @@ export const CurrentMapAtom = atom({
     default: "GROUND",
 });
 
-export const CurrentMyRoomAtom = atom({
+export const CurrentMyRoomAtom = atom<meProps|undefined>({
     key: "CurrentMyRoomAtom",
     default: undefined,
 });

--- a/src/store/PlayersAtom.ts
+++ b/src/store/PlayersAtom.ts
@@ -40,4 +40,18 @@ export const PlayersAtom = atom<PlayerProps[]>({
 });
 
 
+export const IsLoadCompleteAtom = atom({
+    key: "IsLoadCompleteAtom",
+    default: false,
+});
+
+export const CurrentMapAtom = atom({
+    key: "CurrentMapAtom",
+    default: "GROUND",
+});
+
+export const CurrentMyRoomAtom = atom({
+    key: "CurrentMyRoomAtom",
+    default: undefined,
+});
 


### PR DESCRIPTION
## 🔧연결된 이슈
- closed #30 

## 🛠️작업 내용
- SideBar 구현
- React.Suspense + Loader 컴포넌트를 적용 
- UI만 구현했고 맵의 변경에 대한 구현은 아직 미비함 

## 🤷‍♂️PR이 필요한 이유
- 사용자의 위치에 따른 맵 변경을 위한 드롭다운 구현하기 위함
- Loader를 통해 유저의 캐릭터 선택 -> Ground 화면의 연결을 glb파일의 Load여부에 의존을 둠.

## 📸스크린샷 (선택)


https://github.com/user-attachments/assets/7528d2f1-f379-4638-9920-4d81862f3dc3





