### PR TITLE
Feat: 미니맵 구현

### DIFF
--- a/src/components/content/canvas/maps/player/hooks/usePlayer.ts
+++ b/src/components/content/canvas/maps/player/hooks/usePlayer.ts
@@ -6,6 +6,7 @@ import {useGraph,useFrame, RootState} from "@react-three/fiber";
 import {Vector3} from "three";
 import { useRecoilValue } from "recoil";
 import { MeAtom } from "../../../../../../store/PlayersAtom";
+import { calculateMinimapPosition } from "../../../../../../utils/utils";
 
 type ActionName =
     | 'CharacterArmature|CharacterArmature|CharacterArmature|Death'
@@ -55,6 +56,7 @@ interface ModelProps {
 export const usePlayer = ({ player, position,modelIndex }: ModelProps) => {
     const playerId = player?.id ?? ''; // player가 undefined일 수 있으므로 조건부 접근 사용
     const me = useRecoilValue(MeAtom);
+    const point = document.getElementById(`player-point-${playerId}`);
 
     const memoizedPosition = useMemo(() => position, []);
 
@@ -104,6 +106,11 @@ export const usePlayer = ({ player, position,modelIndex }: ModelProps) => {
             const direction = playerRef.current.position.clone().sub(position).normalize().multiplyScalar(0.04);
             playerRef.current.position.sub(direction);
             playerRef.current.lookAt(position);
+
+            if(point){
+                const {x,z} = calculateMinimapPosition(playerRef.current.position);
+                point.style.transform = `translate(${x}px,${z}px)`;
+            }
             setAnimation("CharacterArmature|CharacterArmature|CharacterArmature|Run");
         }
         else{

--- a/src/components/content/canvas/maps/structures/ground/elements/Floor.tsx
+++ b/src/components/content/canvas/maps/structures/ground/elements/Floor.tsx
@@ -14,6 +14,7 @@ const Floor = () => {
             castShadow
             receiveShadow
             rotation-x={-Math.PI / 2}
+            rotation-z={Math.PI / 2}
             position-y={-0.001}
             onPointerUp={(e)=>{
                 socket.emit("move",[e.point.x,0,e.point.z]);

--- a/src/components/content/canvasLayout/Layout.tsx
+++ b/src/components/content/canvasLayout/Layout.tsx
@@ -3,6 +3,7 @@ import { useRecoilValue } from "recoil";
 import { IsLoadCompleteAtom } from "../../../store/PlayersAtom";
 import styled from "styled-components";
 import SideBar from "./canvasUserInterfaces/common/SideBar";
+import Minimap from "./canvasUserInterfaces/ground/Minimap";
 
 interface CanvasLayoutProps {
     children: ReactNode;
@@ -20,7 +21,13 @@ const CanvasLayout = ({children} :CanvasLayoutProps) => {
     return (
         <Wrapper>
             {children}
-            {isLoadCompleted && <SideBar/>}
+            {isLoadCompleted &&
+            (
+                <>
+                    <SideBar/>
+                    <Minimap/>
+                </>
+            )}
         </Wrapper>
     );
 };

--- a/src/components/content/canvasLayout/canvasUserInterfaces/ground/Minimap.tsx
+++ b/src/components/content/canvasLayout/canvasUserInterfaces/ground/Minimap.tsx
@@ -1,0 +1,58 @@
+import { useRecoilValue } from "recoil";
+import { CurrentMapAtom, MeAtom, PlayersAtom } from "../../../../../store/PlayersAtom";
+import styled from "styled-components";
+
+const MinimapWrapper = styled.div`
+    position: fixed;
+    width: 200px;
+    height: 200px;
+    right:50px;
+    bottom:50px;
+    background-color: #0000004b;
+    rotate: 50deg;
+    &:visible{
+        display: block;
+    }
+    &:invisible{
+        display: none;
+    }
+`;  
+
+const PlayerPoint = styled.div`
+    position: absolute;
+    top:100px;
+    left:180px;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    &:me-point{
+        background-color: #59c771;
+    }
+    &:other-point{
+        background-color: #3e3b5f;
+    }
+`;
+
+
+const Minimap = () => {
+    const currentMap = useRecoilValue(CurrentMapAtom);
+    const players = useRecoilValue(PlayersAtom);
+    const me = useRecoilValue(MeAtom);
+
+    return (
+        <MinimapWrapper 
+            className={currentMap === "GROUND" ? "visible" : "invisible"}
+            onContextMenu={(e) => e.preventDefault()}
+            >
+            {players.map((player) => (
+                <PlayerPoint
+                key={player.id}
+                id={`player-point-${player.id}`}
+                className={player.id === me?.id ? "me-point" : "other-point"}
+                />
+            ))}
+        </MinimapWrapper>
+    );
+};
+
+export default Minimap;

--- a/src/components/content/canvasLayout/canvasUserInterfaces/ground/Minimap.tsx
+++ b/src/components/content/canvasLayout/canvasUserInterfaces/ground/Minimap.tsx
@@ -31,7 +31,7 @@ const PlayerPoint = styled.div`
         background-color: #dd1515;
     }
     &.other-point{
-        background-color: #04609e;
+        background-color: #424446;
     }
 `;
 

--- a/src/components/content/canvasLayout/canvasUserInterfaces/ground/Minimap.tsx
+++ b/src/components/content/canvasLayout/canvasUserInterfaces/ground/Minimap.tsx
@@ -25,12 +25,13 @@ const PlayerPoint = styled.div`
     width: 10px;
     height: 10px;
     border-radius: 50%;
+    border: 1px solid #ffffff;
     z-index:999;
     &.me-point{
-        background-color: #59c771;
+        background-color: #dd1515;
     }
     &.other-point{
-        background-color: #3e3b5f;
+        background-color: #04609e;
     }
 `;
 
@@ -39,9 +40,6 @@ const Minimap = () => {
     const currentMap = useRecoilValue(CurrentMapAtom);
     const players = useRecoilValue(PlayersAtom);
     const me = useRecoilValue(MeAtom);
-
-    console.log("Minimap for Players", players);
-    console.log("Minimap for Me", me);
 
     return (
         <MinimapWrapper 

--- a/src/components/content/canvasLayout/canvasUserInterfaces/ground/Minimap.tsx
+++ b/src/components/content/canvasLayout/canvasUserInterfaces/ground/Minimap.tsx
@@ -10,10 +10,10 @@ const MinimapWrapper = styled.div`
     bottom:50px;
     background-color: #0000004b;
     rotate: 50deg;
-    &:visible{
+    &.visible{
         display: block;
     }
-    &:invisible{
+    &.invisible{
         display: none;
     }
 `;  
@@ -21,14 +21,15 @@ const MinimapWrapper = styled.div`
 const PlayerPoint = styled.div`
     position: absolute;
     top:100px;
-    left:180px;
+    left:100px;
     width: 10px;
     height: 10px;
     border-radius: 50%;
-    &:me-point{
+    z-index:999;
+    &.me-point{
         background-color: #59c771;
     }
-    &:other-point{
+    &.other-point{
         background-color: #3e3b5f;
     }
 `;
@@ -38,6 +39,9 @@ const Minimap = () => {
     const currentMap = useRecoilValue(CurrentMapAtom);
     const players = useRecoilValue(PlayersAtom);
     const me = useRecoilValue(MeAtom);
+
+    console.log("Minimap for Players", players);
+    console.log("Minimap for Me", me);
 
     return (
         <MinimapWrapper 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,3 +1,5 @@
+import { Vector3 } from "three";
+
 export const isValidText = (text : string) => {
     return Boolean(text && text.trim() !== "");
 }
@@ -6,4 +8,14 @@ const usernameRegex = /^[a-z]([a-z0-9_]{4,11})$/;
 
 export const isValidNickname  = (nickname:string) => {
     return usernameRegex.test(nickname);
+}
+
+/*
+    미니맵 위치 계산
+*/
+export const calculateMinimapPosition = (originalPosition:Vector3) =>{
+    return {
+        x: 2*originalPosition.x - 5,
+        z: 2*originalPosition.z - 5
+    }
 }


### PR DESCRIPTION
## 🔧연결된 이슈
- closed #32 

## 🛠️작업 내용
- 미니맵 구현
- 미니맵과 GROUND 맵의 매핑 방법은 utils/calculateMinimapPosition을 통해 매칭시킴
- PlayerPoint는 플레이어의 미니맵 상 점(div)이고 "나"와 "다른이"의 구분 기능을 id를 통해 구현함
- flow : `Minimap.tsx` ➡️ PlayerPoint는 div ➡️`hooks/usePlayer.tsx` 에서 `getElementbyId`로 `Minimap.tsx`의 `PlayerPoint` 직접 조종 ➡️ `calculateMinimapPosition` 를 통한 **ground position to minimap position** 좌표 맵핑

## 🤷‍♂️PR이 필요한 이유
- 미니맵을 구현하여 플레이어들의 맵 위의 위치를 보기 위함이다.

## 📸스크린샷 (선택)

https://github.com/user-attachments/assets/10eca7c7-6a56-419a-828e-3a37593a849f
