### PR TITLE
Fix: ChatBubble 동시 표시 문제 해결과 채팅 덮어쓰기 현상

### DIFF
--- a/src/components/content/canvas/maps/structures/ground/3dUIs/ChatBubble.tsx
+++ b/src/components/content/canvas/maps/structures/ground/3dUIs/ChatBubble.tsx
@@ -20,6 +20,12 @@ function ChatBubble({ player, chat }: IChatBubble) {
   const me = useRecoilValue(MeAtom);
   const [visible, setVisible] = useState<boolean>(true);
 
+  useEffect(() => {
+    if (chat) {
+      setVisible(true);
+    }
+  }, [chat]);
+
   const registerShownChat = useCallback(() => {
     if (!chat) return;
     setShownChatMessage((prev) => [...prev, chat]);
@@ -42,13 +48,13 @@ function ChatBubble({ player, chat }: IChatBubble) {
         return prev.filter(
           (recentChat) =>
             recentChat.timeStamp !== chat?.timeStamp &&
-            recentChat.senderId != chat?.senderId
+            recentChat.senderId !== chat?.senderId
         );
       });
       setVisible(false);
     }, 5000);
     return () => clearTimeout(timeout);
-  }, [chat, setRecentChats, setShownChatMessage, visible, registerShownChat]);
+  }, [chat, setRecentChats]);
 
   if (!chat?.text || !visible) return null;
 

--- a/src/components/hooks/useAnimatedText.ts
+++ b/src/components/hooks/useAnimatedText.ts
@@ -15,6 +15,11 @@ export const useAnimatedText = ({
   const [currentIndex, setCurrentIndex] = useState<number>(0);
 
   useEffect(() => {
+    setCurrentIndex(0);
+    setDisplayText("");
+  }, [text]);
+
+  useEffect(() => {
     if (currentIndex < text.length) {
       const timeout = setTimeout(() => {
         setDisplayText(displayText + text[currentIndex]);
@@ -29,9 +34,5 @@ export const useAnimatedText = ({
     }
   }, [callbackFunc, currentIndex, displayText, once, text]);
 
-  useEffect(() => {
-    setCurrentIndex(0);
-    setDisplayText("");
-  }, []);
   return displayText;
 };

--- a/src/store/PlayersAtom.ts
+++ b/src/store/PlayersAtom.ts
@@ -21,7 +21,7 @@ export interface IPlayer {
 
 export interface IChats {
   senderId: string;
-  timeStamp?: Date;
+  timeStamp: number;
   senderNickname: string;
   senderJobPosition: string;
   text: string;


### PR DESCRIPTION
## 🔧연결된 이슈
- closed #45 

## 🛠️작업 내용
- fix: useAnimateText훅에서 text변경시 애니메이션 초기화
- fix : chat변경시 visible상태 초기화
- fix: change type Date to number

## 🤷‍♂️PR이 필요한 이유
- ChatBubble 동시 표시 문제 해결과 채팅 덮어쓰기 현상 해결을 위함

## 📸스크린샷 (선택)
- 없음