### PR TITLE
Fix: 유저의 채팅에서의 메시지 예외처리 

### DIFF
--- a/src/components/content/canvas/maps/structures/ground/3dUIs/ChatBubble.tsx
+++ b/src/components/content/canvas/maps/structures/ground/3dUIs/ChatBubble.tsx
@@ -69,7 +69,7 @@ function ChatBubble({ player, chat }: IChatBubble) {
       visible={visible}
     >
       <RoundedBox
-        args={[2.5, 1, 0.2]} // width, height, depth
+        args={[2.5, 1.3, 0.2]} // width, height, depth
         radius={0.1}
         smoothness={4}
       >
@@ -77,11 +77,13 @@ function ChatBubble({ player, chat }: IChatBubble) {
       </RoundedBox>
       <Text
         position={[0, 0, 0.15]} // 앞쪽으로 살짝 빼줌
-        fontSize={0.3}
+        fontSize={0.2}
         color={me?.id === player.id ? "#276b4f" : "#000000"}
         maxWidth={2.2}
         anchorX="center"
         anchorY="middle"
+        overflowWrap="break-word"
+        whiteSpace="normal"
       >
         {displayText}
       </Text>

--- a/src/components/content/canvasLayout/canvasUserInterfaces/common/ChatBox.tsx
+++ b/src/components/content/canvasLayout/canvasUserInterfaces/common/ChatBox.tsx
@@ -41,13 +41,16 @@ const ChatBox = () => {
     <ChatBoxWrapper isChatCollapsed={isChatCollapsed}>
       <ChatBoxHeader>
         <ChatBoxTitle>Chatting</ChatBoxTitle>
-        <ChatBoxCollapseBtn
-          onClick={() => {
-            setIsChatCollapsed((prev) => !prev);
-          }}
-        >
-          {isChatCollapsed ? <ExpandMoreIcon /> : <ExpandLessIcon />}
-        </ChatBoxCollapseBtn>
+        <HeaderRightContainer>
+          <CountedTextDiv>{tmpText.length}/200</CountedTextDiv>
+          <ChatBoxCollapseBtn
+            onClick={() => {
+              setIsChatCollapsed((prev) => !prev);
+            }}
+          >
+            {isChatCollapsed ? <ExpandMoreIcon /> : <ExpandLessIcon />}
+          </ChatBoxCollapseBtn>
+        </HeaderRightContainer>
       </ChatBoxHeader>
       {!isChatCollapsed && (
         <ChatDropdownWrapper>
@@ -77,6 +80,7 @@ const ChatBox = () => {
           }}
           onKeyUp={handleSubmitEnter}
           placeholder="메시지 입력"
+          maxLength={200}
         />
         <button onClick={handleSubmit}>Send</button>
       </ChatInputContainer>
@@ -212,6 +216,16 @@ const ChatInputBox = styled.input`
   outline: none;
   border: none;
   background-color: #d3d4d49f;
+`;
+
+const CountedTextDiv = styled.div`
+  padding-right: 5px;
+`;
+const HeaderRightContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
 `;
 
 export default ChatBox;

--- a/src/components/content/canvasLayout/canvasUserInterfaces/common/ChatBox.tsx
+++ b/src/components/content/canvasLayout/canvasUserInterfaces/common/ChatBox.tsx
@@ -51,7 +51,7 @@ const ChatBox = () => {
       </ChatBoxHeader>
       {!isChatCollapsed && (
         <ChatDropdownWrapper>
-          <ChatContentCotainer ref={contentRef}>
+          <ChatContentContainer ref={contentRef}>
             {chats?.map(
               ({ senderNickname, senderJobPosition, text }, index: number) => {
                 return (
@@ -63,7 +63,7 @@ const ChatBox = () => {
                 );
               }
             )}
-          </ChatContentCotainer>
+          </ChatContentContainer>
         </ChatDropdownWrapper>
       )}
       <ChatInputContainer>
@@ -151,7 +151,7 @@ const ChatBoxTitle = styled.h4`
   }
 `;
 
-const ChatContentCotainer = styled.div`
+const ChatContentContainer = styled.div`
   padding-left: 10px;
   font-size: 13px;
   width: 100%;

--- a/src/components/hooks/useAnimatedText.ts
+++ b/src/components/hooks/useAnimatedText.ts
@@ -24,7 +24,7 @@ export const useAnimatedText = ({
       const timeout = setTimeout(() => {
         setDisplayText(displayText + text[currentIndex]);
         setCurrentIndex(currentIndex + 1);
-      }, 150);
+      }, 100);
       return () => clearTimeout(timeout);
     } else if (!once) {
       setCurrentIndex(0);


### PR DESCRIPTION
## 🔧연결된 이슈
- closed #47 

## 🛠️작업 내용
- feat : Chatting 글자 제한 수 200자
- chore: 오타수정-ChatContentContainer
- fix: animatedText의 속도 증가
- fix: 줄바꿈 기능과 RoundedBox의 height 크기 조절

## 🤷‍♂️PR이 필요한 이유
- 한번의 채팅 메시지를 200자로 제한함
- 줄바꿈 기능을 더하여 유저의 채팅버블 밖으로 글자가 나가지 않게 함

## 📸스크린샷 (선택)

https://github.com/user-attachments/assets/b26a416d-ec60-4a64-8706-29a53386c530

